### PR TITLE
#6: Disable deprecated register warning in ext

### DIFF
--- a/ext/score_suffix/extconf.rb
+++ b/ext/score_suffix/extconf.rb
@@ -24,7 +24,7 @@ require 'mkmf'
 
 # rubocop:disable Style/GlobalVars
 $warnflags = ''
-$CXXFLAGS << ' -std=c++11'
+$CXXFLAGS << ' -std=c++11 -Wno-deprecated-register'
 $CXXFLAGS.gsub!(/-Wimplicit-int/, '')
 $CXXFLAGS.gsub!(/-Wdeclaration-after-statement/, '')
 $CXXFLAGS.gsub!(/-Wimplicit-function-declaration/, '')


### PR DESCRIPTION
#6: Old version Ruby-dev used deprecated syntax. Disable warning for fix compilation. 