### PR TITLE
#14: Avoid using root ruby.h

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,6 +26,8 @@ install:
         # RubyInstaller2; openssl package seems to be installed already
         $Env:openssl_dir = "C:\msys64\mingw64"
       }
+  - DIR -L C:\Ruby%ruby_version%\include\ruby-2.5.0\
+  - DIR -L C:\Ruby%ruby_version%\include\ruby-2.5.0\ruby
   - bundle config --local path vendor/bundle
   - bundle config build.openssl --with-openssl-dir=%openssl_dir%
   - ruby -v

--- a/ext/score_suffix/ScoreSuffix.cpp
+++ b/ext/score_suffix/ScoreSuffix.cpp
@@ -22,7 +22,7 @@
 #include <random>
 #include <vector>
 #include <openssl/sha.h>
-#include <ruby.h>
+#include <ruby/ruby.h>
 #include <ruby/thread.h>
 
 using namespace std;


### PR DESCRIPTION
This file is not on appveyor images.

Try to use includes from ruby subdirectory.

By issue #14.